### PR TITLE
11.18.23 sdk command - feature - command attributes from properties file

### DIFF
--- a/sdk/command/pom.xml
+++ b/sdk/command/pom.xml
@@ -11,4 +11,20 @@
 
     <artifactId>blckroot.sdk.command</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.blckroot</groupId>
+            <artifactId>blckroot.sdk.file.system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/sdk/command/pom.xml
+++ b/sdk/command/pom.xml
@@ -3,21 +3,12 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>com.blckroot</groupId>
-        <artifactId>com.blckroot</artifactId>
+        <artifactId>com.blckroot.sdk</artifactId>
         <version>1.0.0</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>com.blckroot.sdk</artifactId>
-    <packaging>pom</packaging>
-
-    <modules>
-        <module>logger</module>
-        <module>file-system</module>
-        <module>command</module>
-    </modules>
+    <artifactId>blckroot.sdk.command</artifactId>
 
 </project>

--- a/sdk/command/src/main/java/com/blckroot/Main.java
+++ b/sdk/command/src/main/java/com/blckroot/Main.java
@@ -1,7 +1,16 @@
 package com.blckroot;
 
+import com.blckroot.sdk.command.framework.command.FrameworkBaseCommand;
+import com.blckroot.sdk.command.framework.command.decorator.framework.SetAttributesFromPropertiesFile;
+
 public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
+    public static void main(String[] args) throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(new TestCommand(), "sdk/command/src/test/resources/");
+        int exitCode = command.call();
+
+        System.out.println(command.getVersion());
+        System.out.println(command.getSynopsis());
+        System.out.println(command.getDescription());
+        System.exit(exitCode);
     }
 }

--- a/sdk/command/src/main/java/com/blckroot/Main.java
+++ b/sdk/command/src/main/java/com/blckroot/Main.java
@@ -8,9 +8,8 @@ public class Main {
         FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(new TestCommand(), "sdk/command/src/test/resources/");
         int exitCode = command.call();
 
-        System.out.println(command.getVersion());
-        System.out.println(command.getSynopsis());
-        System.out.println(command.getDescription());
+        System.out.println(command.getProperties().getProperty("1.positional.parameter.label"));
+        System.out.println(command.getPositionalParameters().get(0).getLabel());
         System.exit(exitCode);
     }
 }

--- a/sdk/command/src/main/java/com/blckroot/Main.java
+++ b/sdk/command/src/main/java/com/blckroot/Main.java
@@ -1,0 +1,7 @@
+package com.blckroot;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/TestCommand.java
+++ b/sdk/command/src/main/java/com/blckroot/TestCommand.java
@@ -1,0 +1,15 @@
+package com.blckroot;
+
+import com.blckroot.sdk.command.framework.command.FrameworkCommand;
+
+public class TestCommand extends FrameworkCommand {
+    public TestCommand() {
+        super("test");
+    }
+
+    @Override
+    public Integer call() {
+        System.out.println("TEST COMMAND EXECUTED SUCCESSFULLY");
+        return 0;
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/FrameworkBaseCommand.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/FrameworkBaseCommand.java
@@ -1,0 +1,30 @@
+package com.blckroot.sdk.command.framework.command;
+
+import com.blckroot.sdk.command.model.Option;
+import com.blckroot.sdk.command.model.PositionalParameter;
+
+import java.util.List;
+import java.util.Properties;
+
+public interface FrameworkBaseCommand {
+    Properties getProperties();
+    void setProperties(Properties properties);
+    String getName();
+    String getVersion();
+    void setVersion(String version);
+    String getSynopsis();
+    void setSynopsis(String synopsis);
+    String getDescription();
+    void setDescription(String description);
+    boolean isExecutesWithoutArguments();
+    void setExecutesWithoutArguments(boolean executesWithoutArguments);
+    List<PositionalParameter> getPositionalParameters();
+    void addPositionalParameter(PositionalParameter positionalParameter);
+    List<Option> getOptions();
+    void addOption(Option option);
+    List<FrameworkBaseCommand> getFrameworkSubcommands();
+    void addFrameworkSubcommand(FrameworkBaseCommand subcommand);
+    List<String> getArguments();
+    void addArgument(String argument);
+    Integer call() throws Exception;
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/FrameworkCommand.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/FrameworkCommand.java
@@ -1,0 +1,73 @@
+package com.blckroot.sdk.command.framework.command;
+
+import com.blckroot.sdk.command.model.Command;
+import com.blckroot.sdk.command.model.Option;
+import com.blckroot.sdk.command.model.PositionalParameter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+public class FrameworkCommand extends Command implements FrameworkBaseCommand, Callable<Integer> {
+    private Properties properties;
+    private final List<PositionalParameter> positionalParameters = new ArrayList<>();
+    private final List<Option> options = new ArrayList<>();
+    private final List<FrameworkBaseCommand> frameworkSubcommands = new ArrayList<>();
+    private final List<String> arguments = new ArrayList<>();
+
+    public FrameworkCommand(String name) {
+        super(name);
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public List<PositionalParameter> getPositionalParameters() {
+        return positionalParameters;
+    }
+
+    public void addPositionalParameter(PositionalParameter positionalParameter) {
+        this.positionalParameters.add(positionalParameter);
+    }
+
+    @Override
+    public List<Option> getOptions() {
+        return options;
+    }
+
+    public void addOption(Option option) {
+        this.options.add(option);
+    }
+
+    @Override
+    public List<FrameworkBaseCommand> getFrameworkSubcommands() {
+        return frameworkSubcommands;
+    }
+
+    @Override
+    public void addFrameworkSubcommand(FrameworkBaseCommand subcommand) {
+        frameworkSubcommands.add(subcommand);
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public void addArgument(String argument) {
+        arguments.add(argument);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return 0;
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/FrameworkCommandDecorator.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/FrameworkCommandDecorator.java
@@ -1,0 +1,116 @@
+package com.blckroot.sdk.command.framework.command.decorator;
+
+import com.blckroot.sdk.command.framework.command.FrameworkBaseCommand;
+import com.blckroot.sdk.command.model.Option;
+import com.blckroot.sdk.command.model.PositionalParameter;
+
+import java.util.List;
+import java.util.Properties;
+
+public abstract class FrameworkCommandDecorator implements FrameworkBaseCommand {
+    protected final FrameworkBaseCommand frameworkCommand;
+
+    protected FrameworkCommandDecorator(FrameworkBaseCommand frameworkCommand) {
+        this.frameworkCommand = frameworkCommand;
+    }
+
+    @Override
+    public Properties getProperties() {
+        return this.frameworkCommand.getProperties();
+    }
+
+    @Override
+    public void setProperties(Properties properties) {
+        this.frameworkCommand.setProperties(properties);
+    }
+
+    @Override
+    public String getName() {
+        return this.frameworkCommand.getName();
+    }
+
+    @Override
+    public String getVersion() {
+        return this.frameworkCommand.getVersion();
+    }
+
+    @Override
+    public void setVersion(String version) {
+        this.frameworkCommand.setVersion(version);
+    }
+
+    @Override
+    public String getSynopsis() {
+        return this.frameworkCommand.getSynopsis();
+    }
+
+    @Override
+    public void setSynopsis(String synopsis) {
+        this.frameworkCommand.setSynopsis(synopsis);
+    }
+
+    @Override
+    public String getDescription() {
+        return this.frameworkCommand.getDescription();
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.frameworkCommand.setDescription(description);
+    }
+
+    @Override
+    public boolean isExecutesWithoutArguments() {
+        return this.frameworkCommand.isExecutesWithoutArguments();
+    }
+
+    @Override
+    public void setExecutesWithoutArguments(boolean executesWithoutArguments) {
+        this.frameworkCommand.setExecutesWithoutArguments(executesWithoutArguments);
+    }
+
+    @Override
+    public List<PositionalParameter> getPositionalParameters() {
+        return this.frameworkCommand.getPositionalParameters();
+    }
+
+    @Override
+    public void addPositionalParameter(PositionalParameter positionalParameter) {
+        this.frameworkCommand.addPositionalParameter(positionalParameter);
+    }
+
+    @Override
+    public List<Option> getOptions() {
+        return this.frameworkCommand.getOptions();
+    }
+
+    @Override
+    public void addOption(Option option) {
+        this.frameworkCommand.addOption(option);
+    }
+
+    @Override
+    public List<FrameworkBaseCommand> getFrameworkSubcommands() {
+        return this.frameworkCommand.getFrameworkSubcommands();
+    }
+
+    @Override
+    public void addFrameworkSubcommand(FrameworkBaseCommand subcommand) {
+        this.frameworkCommand.getFrameworkSubcommands().add(subcommand);
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return this.frameworkCommand.getArguments();
+    }
+
+    @Override
+    public void addArgument(String argument) {
+        this.frameworkCommand.addArgument(argument);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return this.frameworkCommand.call();
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFile.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFile.java
@@ -42,7 +42,7 @@ public class SetAttributesFromPropertiesFile extends FrameworkCommandDecorator {
         LOGGER.log(DEBUG, "positional parameters found for framework command: " +
                 frameworkBaseCommand.getName());
         int index = 1;
-        while (index < positionalParameterCount) {
+        while (index <= positionalParameterCount) {
             final String POSITIONAL_PARAMETER_LABEL_KEY = getFormattedKey(index, "positional.parameter.label");
             final String POSITIONAL_PARAMETER_SYNOPSIS_kEY = getFormattedKey(index, "positional.parameter.synopsis");
             final String POSITIONAL_PARAMETER_VALUE_KEY = getFormattedKey(index, "positional.parameter.value");
@@ -87,7 +87,7 @@ public class SetAttributesFromPropertiesFile extends FrameworkCommandDecorator {
         LOGGER.log(DEBUG, "options found for framework command: " + frameworkBaseCommand.getName());
 
         int index = 1;
-        while (index < optionCount) {
+        while (index <= optionCount) {
             final String OPTION_LONG_NAME_KEY = getFormattedKey(index, "option.long.name");
             final String OPTION_SHORT_NAME_KEY = getFormattedKey(index, "option.short.name");
             final String OPTION_SYNOPSIS_KEY = getFormattedKey(index, "option.synopsis");

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFile.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFile.java
@@ -1,0 +1,228 @@
+package com.blckroot.sdk.command.framework.command.decorator.framework;
+
+import com.blckroot.sdk.file.system.service.FileSystemService;
+import com.blckroot.sdk.file.system.validator.FileSystemValidator;
+import com.blckroot.sdk.command.framework.command.FrameworkBaseCommand;
+import com.blckroot.sdk.command.framework.command.FrameworkCommand;
+import com.blckroot.sdk.command.framework.command.decorator.FrameworkCommandDecorator;
+import com.blckroot.sdk.command.model.Option;
+import com.blckroot.sdk.command.model.PositionalParameter;
+
+import java.util.Properties;
+
+import static java.lang.System.Logger.Level.*;
+
+public class SetAttributesFromPropertiesFile extends FrameworkCommandDecorator {
+    private static final System.Logger LOGGER = System.getLogger(SetAttributesFromPropertiesFile.class.getName());
+    private final String propertiesFileDirectory;
+
+    public SetAttributesFromPropertiesFile(FrameworkBaseCommand frameworkCommand, String propertiesFileDirectory) {
+        super(frameworkCommand);
+        LOGGER.log(TRACE, SetAttributesFromPropertiesFile.class.getName());
+        this.propertiesFileDirectory = propertiesFileDirectory;
+        setAttributes(super.frameworkCommand);
+    }
+
+    private String getFormattedKey(Integer keyIndex, String key) {
+        return keyIndex + "." + key;
+    }
+
+    private Boolean propertyIsValid(FrameworkBaseCommand frameworkBaseCommand, String key) {
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+        return frameworkBaseCommand.getProperties().getProperty(key) != null;
+    }
+
+    private Boolean propertiesAreValid(Properties properties) {
+        return properties != null && !properties.isEmpty();
+    }
+
+    private void setPositionalParameters(FrameworkBaseCommand frameworkBaseCommand, Integer positionalParameterCount) {
+        LOGGER.log(DEBUG, "positional parameters found for framework command: " +
+                frameworkBaseCommand.getName());
+        int index = 1;
+        while (index < positionalParameterCount) {
+            final String POSITIONAL_PARAMETER_LABEL_KEY = getFormattedKey(index, "positional.parameter.label");
+            final String POSITIONAL_PARAMETER_SYNOPSIS_kEY = getFormattedKey(index, "positional.parameter.synopsis");
+            final String POSITIONAL_PARAMETER_VALUE_KEY = getFormattedKey(index, "positional.parameter.value");
+
+            LOGGER.log(DEBUG, "creating new positional parameter...");
+            PositionalParameter positionalParameter = new PositionalParameter();
+            if (propertyIsValid(frameworkBaseCommand, POSITIONAL_PARAMETER_LABEL_KEY)) {
+                LOGGER.log(DEBUG, "setting positional parameter label for framework command: " +
+                        frameworkBaseCommand.getName());
+                positionalParameter.setLabel(
+                        frameworkBaseCommand.getProperties().getProperty(POSITIONAL_PARAMETER_LABEL_KEY));
+                LOGGER.log(DEBUG, "positional parameter label: " +
+                        positionalParameter.getLabel());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, POSITIONAL_PARAMETER_SYNOPSIS_kEY)) {
+                LOGGER.log(DEBUG, "setting positional parameter synopsis for framework command: " +
+                        frameworkBaseCommand.getName());
+                positionalParameter.setSynopsis(
+                        frameworkBaseCommand.getProperties().getProperty(POSITIONAL_PARAMETER_SYNOPSIS_kEY));
+                LOGGER.log(DEBUG, "positional parameter description: " +
+                        positionalParameter.getSynopsis());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, POSITIONAL_PARAMETER_VALUE_KEY)) {
+                LOGGER.log(DEBUG, "setting positional parameter value for framework command: " +
+                        frameworkBaseCommand.getName());
+                positionalParameter.setValue(
+                        frameworkBaseCommand.getProperties().getProperty(POSITIONAL_PARAMETER_VALUE_KEY));
+                LOGGER.log(DEBUG, "positional parameter value: " +
+                        positionalParameter.getValue());
+            }
+
+            frameworkBaseCommand.addPositionalParameter(positionalParameter);
+            LOGGER.log(DEBUG, "positional parameter added for framework command: " +
+                    frameworkBaseCommand.getName());
+            index = index + 1;
+        }
+    }
+
+    private void setOptions(FrameworkBaseCommand frameworkBaseCommand, Integer optionCount) {
+        LOGGER.log(DEBUG, "options found for framework command: " + frameworkBaseCommand.getName());
+
+        int index = 1;
+        while (index < optionCount) {
+            final String OPTION_LONG_NAME_KEY = getFormattedKey(index, "option.long.name");
+            final String OPTION_SHORT_NAME_KEY = getFormattedKey(index, "option.short.name");
+            final String OPTION_SYNOPSIS_KEY = getFormattedKey(index, "option.synopsis");
+            final String OPTION_LABEL_KEY = getFormattedKey(index, "option.label");
+            final String OPTION_VALUE_KEY = getFormattedKey(index, "option.value");
+
+            Option option = new Option();
+            if (propertyIsValid(frameworkBaseCommand, OPTION_LONG_NAME_KEY)) {
+                LOGGER.log(DEBUG, "setting option long name for framework command: " +
+                        frameworkBaseCommand.getName());
+                option.setLongName(frameworkBaseCommand.getProperties().getProperty(OPTION_LONG_NAME_KEY));
+                LOGGER.log(DEBUG, "option long name: " + option.getLongName());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, OPTION_SHORT_NAME_KEY)) {
+                LOGGER.log(DEBUG, "setting option short name for framework command: " +
+                        frameworkBaseCommand.getName());
+                option.setShortName(frameworkBaseCommand.getProperties().getProperty(OPTION_SHORT_NAME_KEY));
+                LOGGER.log(DEBUG, "option short name: " + option.getShortName());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, OPTION_SYNOPSIS_KEY)) {
+                LOGGER.log(DEBUG, "setting option synopsis for framework command: " +
+                        frameworkBaseCommand.getName());
+                option.setSynopsis(frameworkBaseCommand.getProperties().getProperty(OPTION_SYNOPSIS_KEY));
+                LOGGER.log(DEBUG, "option synopsis: " + option.getSynopsis());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, OPTION_LABEL_KEY)) {
+                LOGGER.log(DEBUG, "setting option label for framework command: " +
+                        frameworkBaseCommand.getName());
+                option.setLabel(frameworkBaseCommand.getProperties().getProperty(OPTION_LABEL_KEY));
+                LOGGER.log(DEBUG, "option label: " + option.getLabel());
+            }
+
+            if (propertyIsValid(frameworkBaseCommand, OPTION_VALUE_KEY)) {
+                LOGGER.log(DEBUG, "setting option value for framework command: " +
+                        frameworkBaseCommand.getName());
+                option.setValue(frameworkBaseCommand.getProperties().getProperty(OPTION_VALUE_KEY));
+                LOGGER.log(DEBUG, "option value: " + option.getValue());
+            }
+
+            frameworkBaseCommand.addOption(option);
+            LOGGER.log(DEBUG, "option added for framework command: " +
+                    frameworkBaseCommand.getName());
+            index = index + 1;
+        }
+    }
+
+    private void setSubcommands(FrameworkBaseCommand frameworkBaseCommand, String[] subcommandNames) {
+        LOGGER.log(DEBUG, "subcommands found for framework command: " + frameworkBaseCommand.getName());
+        for (String subcommandName : subcommandNames) {
+            LOGGER.log(DEBUG, "creating subcommand: " + subcommandName);
+            FrameworkBaseCommand subcommand =
+                    new SetAttributesFromPropertiesFile(new FrameworkCommand(subcommandName), propertiesFileDirectory);
+            setAttributes(subcommand);
+            frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+        }
+    }
+
+    private void setAttributes(FrameworkBaseCommand frameworkBaseCommand) {
+        LOGGER.log(DEBUG, "setting attributes for framework command: " + frameworkBaseCommand.getName());
+        String propertiesFilePath = propertiesFileDirectory + frameworkBaseCommand.getName() + ".properties";
+
+        FileSystemValidator fileValidator = new FileSystemValidator();
+        if (!fileValidator.fileExists(propertiesFilePath)) {
+            LOGGER.log(ERROR, "properties file does not exist: " + propertiesFilePath);
+//            TODO: improve handling behavior
+            return;
+        }
+
+        FileSystemService fileSystemService = new FileSystemService();
+        LOGGER.log(DEBUG, "setting properties from properties file path: " + propertiesFilePath);
+        frameworkBaseCommand.setProperties(fileSystemService.getPropertiesFromFile(propertiesFilePath));
+
+        if (!propertiesAreValid(frameworkBaseCommand.getProperties())) {
+            LOGGER.log(ERROR, "failed to read properties from properties file: " + propertiesFilePath);
+//            TODO: improve handling behavior
+            return;
+        }
+
+        final String VERSION_PROPERTY_KEY = "version";
+        final String SYNOPSIS_PROPERTY_KEY = "synopsis";
+        final String DESCRIPTION_PROPERTY_KEY = "description";
+        final String EXECUTES_WITHOUT_ARGUMENTS_KEY = "executes.without.arguments";
+        final String POSITIONAL_PARAMETER_COUNT_PROPERTY_KEY = "positional.parameter.count";
+        final String OPTION_COUNT_PROPERTY_KEY = "option.count";
+        final String SUBCOMMANDS_PROPERTY_KEY = "subcommands";
+
+        if (propertyIsValid(frameworkBaseCommand, VERSION_PROPERTY_KEY)) {
+            LOGGER.log(DEBUG, "setting version for framework command: " + frameworkBaseCommand.getName());
+            frameworkBaseCommand.setVersion(frameworkBaseCommand.getProperties().getProperty(VERSION_PROPERTY_KEY));
+            LOGGER.log(DEBUG, "version for framework command: " + frameworkBaseCommand.getVersion());
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, SYNOPSIS_PROPERTY_KEY)) {
+            LOGGER.log(DEBUG, "setting synopsis for framework command: " + frameworkBaseCommand.getName());
+            frameworkBaseCommand.setSynopsis(frameworkBaseCommand.getProperties().getProperty(SYNOPSIS_PROPERTY_KEY));
+            LOGGER.log(DEBUG, "synopsis for framework command: " + frameworkBaseCommand.getSynopsis());
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, DESCRIPTION_PROPERTY_KEY)) {
+            LOGGER.log(DEBUG, "setting description for framework command: " + frameworkBaseCommand.getName());
+            frameworkBaseCommand.setDescription
+                    (frameworkBaseCommand.getProperties().getProperty(DESCRIPTION_PROPERTY_KEY));
+            LOGGER.log(DEBUG, "description for framework command: " + frameworkBaseCommand.getDescription());
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, EXECUTES_WITHOUT_ARGUMENTS_KEY)) {
+            LOGGER.log(DEBUG, "setting executes without arguments for framework command: " + frameworkBaseCommand.getName());
+            frameworkBaseCommand.setExecutesWithoutArguments(Boolean.parseBoolean(
+                    frameworkBaseCommand.getProperties().getProperty(EXECUTES_WITHOUT_ARGUMENTS_KEY)));
+            LOGGER.log(DEBUG, "executes without arguments for framework command: " +
+                    frameworkBaseCommand.isExecutesWithoutArguments());
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, POSITIONAL_PARAMETER_COUNT_PROPERTY_KEY)) {
+            setPositionalParameters(frameworkBaseCommand, Integer.valueOf(
+                    frameworkBaseCommand.getProperties().getProperty(POSITIONAL_PARAMETER_COUNT_PROPERTY_KEY)));
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, OPTION_COUNT_PROPERTY_KEY)) {
+            setOptions(frameworkBaseCommand, Integer.valueOf(
+                    frameworkBaseCommand.getProperties().getProperty(OPTION_COUNT_PROPERTY_KEY)));
+        }
+
+        if (propertyIsValid(frameworkBaseCommand, SUBCOMMANDS_PROPERTY_KEY)) {
+            setSubcommands(frameworkBaseCommand,
+                    frameworkBaseCommand.getProperties().getProperty(SUBCOMMANDS_PROPERTY_KEY).split(","));
+        }
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        LOGGER.log(TRACE, "execute call method: " + SetAttributesFromPropertiesFile.class.getName());
+        return super.call();
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/model/Command.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/model/Command.java
@@ -1,0 +1,49 @@
+package com.blckroot.sdk.command.model;
+
+public class Command {
+    private final String name;
+    private String version;
+    private String synopsis;
+    private String description;
+    private Boolean executesWithoutArguments = false;
+
+    public Command(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getSynopsis() {
+        return synopsis;
+    }
+
+    public void setSynopsis(String synopsis) {
+        this.synopsis = synopsis;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isExecutesWithoutArguments() {
+        return executesWithoutArguments;
+    }
+
+    public void setExecutesWithoutArguments(boolean executesWithoutArguments) {
+        this.executesWithoutArguments = executesWithoutArguments;
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/model/Option.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/model/Option.java
@@ -1,0 +1,49 @@
+package com.blckroot.sdk.command.model;
+
+public class Option {
+    private String longName;
+    private String shortName;
+    private String synopsis;
+    private String label;
+    private Object value;
+
+    public String getLongName() {
+        return longName;
+    }
+
+    public void setLongName(String longName) {
+        this.longName = longName;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    public String getSynopsis() {
+        return synopsis;
+    }
+
+    public void setSynopsis(String synopsis) {
+        this.synopsis = synopsis;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/model/PositionalParameter.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/model/PositionalParameter.java
@@ -1,0 +1,31 @@
+package com.blckroot.sdk.command.model;
+
+public class PositionalParameter {
+    private String label;
+    private String synopsis;
+    private Object value;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getSynopsis() {
+        return synopsis;
+    }
+
+    public void setSynopsis(String synopsis) {
+        this.synopsis = synopsis;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
@@ -272,4 +272,69 @@ public class SetAttributesFromPropertiesFileTest {
         String actual = command.getOptions().get(0).getValue().toString();
         assertEquals(expected, actual);
     }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_long_name__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.option.long.name");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(1).getLongName();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_short_name__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.option.short.name");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(1).getShortName();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_synopsis__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.option.synopsis");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(1).getSynopsis();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_label__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.option.label");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(1).getLabel();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_value__boolean__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        boolean expected = Boolean.parseBoolean(properties.getProperty("2.option.value"));
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        boolean actual = (boolean) !command.getOptions().get(1).getValue().toString().isBlank();
+        assertEquals(expected, actual);
+    }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
@@ -13,6 +13,8 @@ public class SetAttributesFromPropertiesFileTest {
     private final String VALID_PROPERTIES_DIRECTORY = "src/test/resources/";
     private final String VALID_PROPERTIES_FILE_PATH = VALID_PROPERTIES_DIRECTORY + "test.properties";
 
+    // Command Model Attributes
+
     @Test
     void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__null() throws Exception {
         FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
@@ -98,8 +100,23 @@ public class SetAttributesFromPropertiesFileTest {
         assertEquals(expected, actual);
     }
 
+    // Framework Command Positional Parameters
+
     @Test
-    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__label() throws Exception {
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter_count() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        int expected = Integer.parseInt(properties.getProperty("positional.parameter.count"));
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        int actual = command.getPositionalParameters().size();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__label__first_index() throws Exception {
         FileSystemService fileSystemService = new FileSystemService();
         Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
         String expected = properties.getProperty("1.positional.parameter.label");
@@ -112,7 +129,7 @@ public class SetAttributesFromPropertiesFileTest {
     }
 
     @Test
-    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__synopsis() throws Exception {
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__synopsis__first_index() throws Exception {
         FileSystemService fileSystemService = new FileSystemService();
         Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
         String expected = properties.getProperty("1.positional.parameter.synopsis");
@@ -125,7 +142,7 @@ public class SetAttributesFromPropertiesFileTest {
     }
 
     @Test
-    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__value__string() throws Exception {
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__value__string__first_index() throws Exception {
         FileSystemService fileSystemService = new FileSystemService();
         Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
         String expected = properties.getProperty("1.positional.parameter.value");
@@ -134,6 +151,125 @@ public class SetAttributesFromPropertiesFileTest {
                 new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
         command.call();
         String actual = (String) command.getPositionalParameters().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__label__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.positional.parameter.label");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getPositionalParameters().get(1).getLabel();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__synopsis__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("2.positional.parameter.synopsis");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getPositionalParameters().get(1).getSynopsis();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__value__boolean__second_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        boolean expected = Boolean.parseBoolean(properties.getProperty("2.positional.parameter.value"));
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        boolean actual = !command.getPositionalParameters().get(1).getValue().toString().isBlank();
+        assertEquals(expected, actual);
+    }
+
+    // Framework Command Options
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_count() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        int expected = Integer.parseInt(properties.getProperty("option.count"));
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        int actual = command.getOptions().size();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_long_name__first_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.option.long.name");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(0).getLongName();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_short_name__first_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.option.short.name");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(0).getShortName();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_synopsis__first_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.option.synopsis");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(0).getSynopsis();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_label__first_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.option.label");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(0).getLabel();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__option_value__string__first_index() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.option.value");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getOptions().get(0).getValue().toString();
         assertEquals(expected, actual);
     }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
@@ -337,4 +337,18 @@ public class SetAttributesFromPropertiesFileTest {
         boolean actual = (boolean) !command.getOptions().get(1).getValue().toString().isBlank();
         assertEquals(expected, actual);
     }
+
+    // Framework Command Subcommands
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__subcommands() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        int expected = properties.getProperty("subcommands").split(",").length;
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        int actual = command.getFrameworkSubcommands().size();
+    }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
@@ -1,0 +1,139 @@
+package com.blckroot.sdk.command.framework.command.decorator.framework;
+
+import com.blckroot.sdk.command.framework.command.FrameworkBaseCommand;
+import com.blckroot.sdk.command.framework.command.FrameworkCommand;
+import com.blckroot.sdk.file.system.service.FileSystemService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SetAttributesFromPropertiesFileTest {
+    private final String VALID_PROPERTIES_DIRECTORY = "src/test/resources/";
+    private final String VALID_PROPERTIES_FILE_PATH = VALID_PROPERTIES_DIRECTORY + "test.properties";
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__null() throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), null);
+        command.call();
+        assertNull(command.getProperties());
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__empty() throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), "");
+        command.call();
+        assertNull(command.getProperties());
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__blank() throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), "   ");
+        command.call();
+        assertNull(command.getProperties());
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__invalid() throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), "src/test/");
+        command.call();
+        assertNull(command.getProperties());
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__version() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("version");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+
+        String actual = command.getVersion();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__synopsis() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("synopsis");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getSynopsis();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__description() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("description");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getDescription();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__executes_without_arguments() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        boolean expected = Boolean.parseBoolean(properties.getProperty("executes.without.arguments"));
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        boolean actual = command.isExecutesWithoutArguments();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__label() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.positional.parameter.label");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getPositionalParameters().get(0).getLabel();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__synopsis() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.positional.parameter.synopsis");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = command.getPositionalParameters().get(0).getSynopsis();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__positional_parameter__value__string() throws Exception {
+        FileSystemService fileSystemService = new FileSystemService();
+        Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);
+        String expected = properties.getProperty("1.positional.parameter.value");
+
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        String actual = (String) command.getPositionalParameters().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+}

--- a/sdk/command/src/test/resources/subtesta.properties
+++ b/sdk/command/src/test/resources/subtesta.properties
@@ -1,0 +1,24 @@
+version=1.0.0
+synopsis=subtesta command synopsis.
+description=Full subtesta command description with examples.
+
+positional.parameter.count=1
+
+1.positional.parameter.label=positionalParameterA
+1.positional.parameter.synopsis=positionalParameterA synopsis.
+1.positional.parameter.value=positionalParameterA value
+
+option.count=3
+
+1.option.long.name=--optionA
+1.option.short.name=-a
+1.option.synopsis=OptionA synopsis.
+1.option.label=<labelA>
+1.option.value=OptionA value
+
+2.option.long.name=--optionB
+2.option.synopsis=OptionB synopsis.
+2.option.value=true
+
+3.option.long.name=--optionC
+3.option.synopsis=OptionC synopsis.

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -1,3 +1,9 @@
 version=1.0.0
 synopsis=Test command synopsis.
 description=Full test command description with examples.
+executes.without.arguments=true
+
+positional.parameter.count=1
+1.positional.parameter.label=positionalParameterA
+1.positional.parameter.synopsis=positionalParameterA synopsis.
+1.positional.parameter.value=positionalParameterA value

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+version=1.0.0
+synopsis=Test command synopsis.
+description=Full test command description with examples.

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -24,3 +24,5 @@ option.count=2
 2.option.long.name=--optionA
 2.option.synopsis=OptionA synopsis.
 2.option.value=true
+
+subcommands=subTestA,subTestB

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -18,4 +18,9 @@ option.count=2
 1.option.long.name=--optionA
 1.option.short.name=-a
 1.option.synopsis=OptionA synopsis.
+1.option.label=<labelA>
 1.option.value=OptionA value
+
+2.option.long.name=--optionA
+2.option.synopsis=OptionA synopsis.
+2.option.value=true

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -25,4 +25,4 @@ option.count=2
 2.option.synopsis=OptionA synopsis.
 2.option.value=true
 
-subcommands=subTestA,subTestB
+subcommands=subtesta

--- a/sdk/command/src/test/resources/test.properties
+++ b/sdk/command/src/test/resources/test.properties
@@ -3,7 +3,19 @@ synopsis=Test command synopsis.
 description=Full test command description with examples.
 executes.without.arguments=true
 
-positional.parameter.count=1
+positional.parameter.count=2
+
 1.positional.parameter.label=positionalParameterA
 1.positional.parameter.synopsis=positionalParameterA synopsis.
 1.positional.parameter.value=positionalParameterA value
+
+2.positional.parameter.label=positionalParameterB
+2.positional.parameter.synopsis=positionalParameterB synopsis.
+2.positional.parameter.value=true
+
+option.count=2
+
+1.option.long.name=--optionA
+1.option.short.name=-a
+1.option.synopsis=OptionA synopsis.
+1.option.value=OptionA value

--- a/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemService.java
+++ b/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemService.java
@@ -1,0 +1,22 @@
+package com.blckroot.sdk.file.system.service;
+
+import java.util.Properties;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.TRACE;
+
+public class FileSystemService implements FileSystemServiceContract {
+    private static final System.Logger LOGGER = System.getLogger(FileSystemService.class.getName());
+    private final FileSystemServiceUtility fileSystemServiceUtility;
+
+    public FileSystemService() {
+        this.fileSystemServiceUtility = new FileSystemServiceUtility();
+        LOGGER.log(TRACE, "instantiated: " + fileSystemServiceUtility.getClass().getName());
+    }
+
+    @Override
+    public Properties getPropertiesFromFile(String propertiesFile) {
+        LOGGER.log(DEBUG, "getting properties from file: " + propertiesFile);
+        return fileSystemServiceUtility.getPropertiesFromFile(propertiesFile);
+    }
+}

--- a/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemServiceContract.java
+++ b/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemServiceContract.java
@@ -1,0 +1,7 @@
+package com.blckroot.sdk.file.system.service;
+
+import java.util.Properties;
+
+interface FileSystemServiceContract {
+    Properties getPropertiesFromFile(String propertiesFile);
+}

--- a/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemServiceUtility.java
+++ b/sdk/file-system/src/main/java/com/blckroot/sdk/file/system/service/FileSystemServiceUtility.java
@@ -1,0 +1,26 @@
+package com.blckroot.sdk.file.system.service;
+
+import com.blckroot.sdk.file.system.validator.FileSystemValidator;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+class FileSystemServiceUtility implements FileSystemServiceContract {
+    @Override
+    public Properties getPropertiesFromFile(String propertiesFile) {
+        FileSystemValidator fileSystemValidator = new FileSystemValidator();
+        if (!fileSystemValidator.fileExists(propertiesFile)) {
+            return null;
+        }
+
+        try (InputStream inputStream = new FileInputStream(propertiesFile)) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/sdk/file-system/src/test/java/com/blckroot/sdk/file/system/service/FileSystemServiceTest.java
+++ b/sdk/file-system/src/test/java/com/blckroot/sdk/file/system/service/FileSystemServiceTest.java
@@ -1,0 +1,43 @@
+package com.blckroot.sdk.file.system.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileSystemServiceTest {
+
+    @Test
+    void FILE_SYSTEM_SERVICE__get_properties_from_file__file_path_null() {
+        FileSystemService fileSystemService = new FileSystemService();
+        assertNull(fileSystemService.getPropertiesFromFile(null));
+    }
+
+    @Test
+    void FILE_SYSTEM_SERVICE__get_properties_from_file__file_path_empty() {
+        FileSystemService fileSystemService = new FileSystemService();
+        assertNull(fileSystemService.getPropertiesFromFile(""));
+    }
+
+    @Test
+    void FILE_SYSTEM_SERVICE__get_properties_from_file__file_path_blank() {
+        FileSystemService fileSystemService = new FileSystemService();
+        assertNull(fileSystemService.getPropertiesFromFile("   "));
+    }
+
+    @Test
+    void FILE_SYSTEM_SERVICE__get_properties_from_file__file_path_does_not_exist() {
+        FileSystemService fileSystemService = new FileSystemService();
+        assertNull(fileSystemService.getPropertiesFromFile("src/test/resources/bad.properties"));
+    }
+
+    @Test
+    void FILE_SYSTEM_SERVICE__get_properties_from_file__file_path_exists() {
+        String expected = "valueA";
+        FileSystemService fileSystemService = new FileSystemService();
+        String actual = fileSystemService
+                .getPropertiesFromFile("src/test/resources/test.properties")
+                .getProperty("keyA");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/sdk/file-system/src/test/resources/test.properties
+++ b/sdk/file-system/src/test/resources/test.properties
@@ -1,0 +1,3 @@
+keyA=valueA
+keyB=valueB
+keyC=valueC


### PR DESCRIPTION
- setting command attributes from properties file at runtime.
- command attributes being set: version, synopsis, description, executesWithoutArguments.
- setting positional parameter attributes from properties file at runtime.
- positional parameter attributes being set: label, synopsis, value(optional).
- setting option attributes from properties file at runtime.
- option attributes being set: longName, shortName(optional), synopsis, label(optional), value(optional).
- assembling subcommand(s) from properties file at runtime, including subcommand attributes, positional parameters, and options from appropriately named 'subcommand.properties' file in same directory as parent 'command.properties' file.