### PR TITLE
11.18.23 sdk command

### DIFF
--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/CommandFrameworkContract.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/CommandFrameworkContract.java
@@ -1,5 +1,5 @@
 package com.blckroot.sdk.command.framework;
 
 interface CommandFrameworkContract {
-    Integer execute(String[] arguments);
+    Integer execute(String[] arguments) throws Exception;
 }

--- a/sdk/command/src/main/java/com/blckroot/sdk/command/framework/CommandFrameworkUtility.java
+++ b/sdk/command/src/main/java/com/blckroot/sdk/command/framework/CommandFrameworkUtility.java
@@ -1,7 +1,16 @@
 package com.blckroot.sdk.command.framework;
 
 import com.blckroot.sdk.command.framework.command.FrameworkBaseCommand;
+import com.blckroot.sdk.command.model.Option;
+import com.blckroot.sdk.command.model.PositionalParameter;
 import picocli.CommandLine;
+import picocli.CommandLine.ParseResult;
+import picocli.CommandLine.Model.PositionalParamSpec;
+import picocli.CommandLine.Model.OptionSpec;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
 
 class CommandFrameworkUtility implements CommandFrameworkContract {
     private final FrameworkBaseCommand frameworkBaseCommand;
@@ -10,9 +19,103 @@ class CommandFrameworkUtility implements CommandFrameworkContract {
         this.frameworkBaseCommand = frameworkBaseCommand;
     }
 
+    private Integer usageHelp(CommandLine commandLine) {
+        commandLine.usage(commandLine.getOut());
+        return commandLine.getCommandSpec().exitCodeOnUsageHelp();
+    }
+
+    private Integer versionHelp(CommandLine commandLine) {
+        commandLine.printVersionHelp(commandLine.getOut());
+        return commandLine.getCommandSpec().exitCodeOnVersionHelp();
+    }
+
+    private FrameworkBaseCommand getFrameworkBaseCommandForParseResult(ParseResult parseResult) {
+        String frameworkBaseCommandName = parseResult.commandSpec().name();
+        if (frameworkBaseCommandName.equalsIgnoreCase(frameworkBaseCommand.getName())) {
+            return frameworkBaseCommand;
+        }
+
+        if (!frameworkBaseCommand.getFrameworkSubcommands().isEmpty()) {
+            Queue<FrameworkBaseCommand> frameworkBaseCommandQueue =
+                    new ArrayDeque<>(frameworkBaseCommand.getFrameworkSubcommands());
+            while (!frameworkBaseCommandQueue.isEmpty()) {
+                FrameworkBaseCommand currentFrameworkBaseCommand = frameworkBaseCommandQueue.remove();
+                if (frameworkBaseCommandName.equalsIgnoreCase(currentFrameworkBaseCommand.getName())) {
+                    return currentFrameworkBaseCommand;
+                }
+                frameworkBaseCommandQueue.addAll(currentFrameworkBaseCommand.getFrameworkSubcommands());
+            }
+        }
+        return null;
+    }
+
     @Override
     public Integer execute(String[] arguments) {
         CommandLine commandLine = new CommandLineBuilder(frameworkBaseCommand).build();
-        return commandLine.execute(arguments);
+        ParseResult parseResult = commandLine.parseArgs(arguments);
+
+        try {
+            Queue<CommandLine> commandLineQueue = new ArrayDeque<>(parseResult.asCommandLineList());
+            while (!commandLineQueue.isEmpty()) {
+                CommandLine currentCommandLine = commandLineQueue.remove();
+
+                if (currentCommandLine.isUsageHelpRequested()) {
+                    return usageHelp(currentCommandLine);
+                }
+
+                if (currentCommandLine.isVersionHelpRequested()) {
+                    return versionHelp(currentCommandLine);
+                }
+
+                ParseResult currentParseResult = currentCommandLine.getParseResult();
+                FrameworkBaseCommand currentFrameworkBaseCommand =
+                        getFrameworkBaseCommandForParseResult(currentParseResult);
+                if (currentFrameworkBaseCommand == null) {
+                    return 0;
+                }
+
+                if (currentParseResult.expandedArgs().isEmpty()) {
+                    if (currentFrameworkBaseCommand.isExecutesWithoutArguments()) {
+                        return currentFrameworkBaseCommand.call();
+                    }
+                    return usageHelp(currentCommandLine);
+                }
+
+                List<PositionalParameter> positionalParameters = currentFrameworkBaseCommand.getPositionalParameters();
+                if (!positionalParameters.isEmpty()) {
+                    List<PositionalParamSpec> matchedPositionalParameters = currentParseResult.matchedPositionals();
+                    if (!matchedPositionalParameters.isEmpty()) {
+                        currentFrameworkBaseCommand.getPositionalParameters().forEach(positionalParameter -> {
+                            matchedPositionalParameters.forEach(positionalParamSpec -> {
+                                if (positionalParameter.getLabel().equalsIgnoreCase(positionalParamSpec.paramLabel())) {
+                                    positionalParameter.setValue(positionalParamSpec.getValue());
+                                }
+                            });
+                        });
+                    }
+                }
+
+                List<Option> options = currentFrameworkBaseCommand.getOptions();
+                if (!options.isEmpty()) {
+                    List<OptionSpec> matchedOptions = currentParseResult.matchedOptions();
+                    if (!matchedOptions.isEmpty()) {
+                        options.forEach(option -> {
+                            matchedOptions.forEach(optionSpec -> {
+                                if (option.getLongName().equalsIgnoreCase(optionSpec.longestName())) {
+                                    option.setValue(optionSpec.getValue());
+                                }
+                            });
+                        });
+                    }
+                }
+
+                if (commandLineQueue.isEmpty()) {
+                    return currentFrameworkBaseCommand.call();
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return 0;
     }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
@@ -580,4 +580,67 @@ public class CommandFrameworkTest {
         int actual = commandFramework.execute(new String[]{"--version"});
         assertTrue(out.toString().contains(frameworkBaseCommandVersion));
     }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__positional_parameter() {
+        String expected = "first positional parameter value";
+        frameworkBaseCommand.addPositionalParameter(getPositionalParameter());
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{expected});
+
+        String actual = frameworkBaseCommand.getPositionalParameters().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__boolean() {
+        boolean expected = true;
+        Option option = getOption();
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{option.getLongName()});
+
+        boolean actual = (boolean) frameworkBaseCommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__boolean() {
+        boolean expected = true;
+        Option option = getOption();
+        addOptionShortName(option);
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{option.getShortName()});
+
+        boolean actual = (boolean) frameworkBaseCommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__string() {
+        String expected = "option value";
+        Option option = getOption();
+        addOptionLabel(option);
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{option.getLongName(), expected});
+
+        String actual = frameworkBaseCommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__string() {
+        String expected = "option value";
+        Option option = getOption();
+        addOptionShortName(option);
+        addOptionLabel(option);
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{option.getShortName(), expected});
+
+        String actual = frameworkBaseCommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
@@ -65,6 +65,12 @@ public class CommandFrameworkTest {
         return subcommand;
     }
 
+    FrameworkBaseCommand getNestedSubcommand() {
+        FrameworkBaseCommand subcommand = new FrameworkCommand("subtestB");
+        subcommand.setSynopsis("subtestB synopsis");
+        return subcommand;
+    }
+
     @Test
     void COMMAND_FRAMEWORK__usage_help__short_option__exit_code__success() {
         int expected = 0;
@@ -965,6 +971,104 @@ public class CommandFrameworkTest {
         commandFramework.execute(new String[]{subcommand.getName(), option.getShortName(), expected});
 
         String actual = subcommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__positional_parameter__nested_subcommand() {
+        String expected = "first positional parameter value";
+
+        FrameworkBaseCommand nestedSubcommand = getNestedSubcommand();
+        nestedSubcommand.addPositionalParameter(getPositionalParameter());
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addFrameworkSubcommand(nestedSubcommand);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), nestedSubcommand.getName(), expected});
+
+        String actual = nestedSubcommand.getPositionalParameters().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__boolean__nested_subcommand() {
+        boolean expected = true;
+
+        FrameworkBaseCommand nestedSubcommand = getNestedSubcommand();
+        Option option = getOption();
+        nestedSubcommand.addOption(option);
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addFrameworkSubcommand(nestedSubcommand);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), nestedSubcommand.getName(), option.getLongName()});
+
+        boolean actual = (boolean) nestedSubcommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__boolean__nested_subcommand() {
+        boolean expected = true;
+
+        FrameworkBaseCommand nestedSubcommand = getNestedSubcommand();
+        Option option = getOption();
+        addOptionShortName(option);
+        nestedSubcommand.addOption(option);
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addFrameworkSubcommand(nestedSubcommand);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), nestedSubcommand.getName(), option.getShortName()});
+
+        boolean actual = (boolean) nestedSubcommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__string__nested_subcommand() {
+        String expected = "option value";
+
+        FrameworkBaseCommand nestedSubcommand = getNestedSubcommand();
+        Option option = getOption();
+        addOptionLabel(option);
+        nestedSubcommand.addOption(option);
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addFrameworkSubcommand(nestedSubcommand);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), nestedSubcommand.getName(), option.getLongName(), expected});
+
+        String actual = nestedSubcommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__string__nested_subcommand() {
+        String expected = "option value";
+
+        FrameworkBaseCommand nestedSubcommand = getNestedSubcommand();
+        Option option = getOption();
+        addOptionShortName(option);
+        addOptionLabel(option);
+        nestedSubcommand.addOption(option);
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addFrameworkSubcommand(nestedSubcommand);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), nestedSubcommand.getName(), option.getShortName(), expected});
+
+        String actual = nestedSubcommand.getOptions().get(0).getValue().toString();
         assertEquals(expected, actual);
     }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
@@ -548,14 +548,6 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__version_help__short_option__exit_code__failure() {
-        int expected = 2;
-        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
-        int actual = commandFramework.execute(new String[]{"-v"});
-        assertEquals(expected, actual);
-    }
-
-    @Test
     void COMMAND_FRAMEWORK__version_help__short_option__exit_code__success() {
         int expected = 0;
         frameworkBaseCommand.setVersion(frameworkBaseCommandVersion);
@@ -570,14 +562,6 @@ public class CommandFrameworkTest {
         CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
         int actual = commandFramework.execute(new String[]{"-v"});
         assertTrue(out.toString().contains(frameworkBaseCommandVersion));
-    }
-
-    @Test
-    void COMMAND_FRAMEWORK__version_help__long_option__exit_code__failure() {
-        int expected = 2;
-        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
-        int actual = commandFramework.execute(new String[]{"--version"});
-        assertEquals(expected, actual);
     }
 
     @Test

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/CommandFrameworkTest.java
@@ -548,6 +548,247 @@ public class CommandFrameworkTest {
     }
 
     @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__exit_code__success() {
+        int expected = 0;
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        int actual = commandFramework.execute(new String[]{});
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_name() {
+        String expected = frameworkBaseCommand.getName();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(expected));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_version__short() {
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{"--help"});
+
+        assertFalse(out.toString().contains("-v"));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_version__long() {
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains("--version"));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_version__short() {
+        frameworkBaseCommand.setVersion(frameworkBaseCommandVersion);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains("-v"));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_version__long() {
+        frameworkBaseCommand.setVersion(frameworkBaseCommandVersion);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains("--version"));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_synopsis() {
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(frameworkBaseCommandSynopsis));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_synopsis() {
+        frameworkBaseCommand.setSynopsis(frameworkBaseCommandSynopsis);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(frameworkBaseCommandSynopsis));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_description() {
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(getFrameworkBaseCommandDescription));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_description() {
+        frameworkBaseCommand.setDescription(getFrameworkBaseCommandDescription);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(getFrameworkBaseCommandDescription));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_positional_parameter__label() {
+        PositionalParameter positionalParameter = getPositionalParameter();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(positionalParameter.getLabel()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_positional_parameter__label() {
+        PositionalParameter positionalParameter = getPositionalParameter();
+        frameworkBaseCommand.addPositionalParameter(positionalParameter);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(positionalParameter.getLabel()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_positional_parameter__synopsis() {
+        PositionalParameter positionalParameter = getPositionalParameter();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(positionalParameter.getSynopsis()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_positional_parameter__synopsis() {
+        PositionalParameter positionalParameter = getPositionalParameter();
+        frameworkBaseCommand.addPositionalParameter(positionalParameter);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(positionalParameter.getSynopsis()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_option__long_name() {
+        Option option = getOption();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(option.getLongName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_option__long_name() {
+        Option option = getOption();
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(option.getLongName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_option__synopsis() {
+        Option option = getOption();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(option.getSynopsis()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_option__synopsis() {
+        Option option = getOption();
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(option.getSynopsis()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_option__short_name() {
+        Option option = getOption();
+        addOptionShortName(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(option.getShortName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_option__short_name() {
+        Option option = getOption();
+        addOptionShortName(option);
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(option.getShortName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_option__label() {
+        Option option = getOption();
+        addOptionLabel(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(option.getLabel()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_option__label() {
+        Option option = getOption();
+        addOptionLabel(option);
+        frameworkBaseCommand.addOption(option);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(option.getLabel()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_subcommand__name() {
+        FrameworkBaseCommand subcommand = getSubcommand();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(subcommand.getName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_subcommand__name() {
+        FrameworkBaseCommand subcommand = getSubcommand();
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(subcommand.getName()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_no_subcommand__synopsis() {
+        FrameworkBaseCommand subcommand = getSubcommand();
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertFalse(out.toString().contains(subcommand.getSynopsis()));
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__usage_help__no_arguments__output__command_subcommand__synopsis() {
+        FrameworkBaseCommand subcommand = getSubcommand();
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{});
+
+        assertTrue(out.toString().contains(subcommand.getSynopsis()));
+    }
+
+    @Test
     void COMMAND_FRAMEWORK__version_help__short_option__exit_code__success() {
         int expected = 0;
         frameworkBaseCommand.setVersion(frameworkBaseCommandVersion);
@@ -582,7 +823,7 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__parse__positional_parameter() {
+    void COMMAND_FRAMEWORK__parse__positional_parameter__base_command() {
         String expected = "first positional parameter value";
         frameworkBaseCommand.addPositionalParameter(getPositionalParameter());
         CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
@@ -593,7 +834,7 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__parse__option__long_name__boolean() {
+    void COMMAND_FRAMEWORK__parse__option__long_name__boolean__base_command() {
         boolean expected = true;
         Option option = getOption();
         frameworkBaseCommand.addOption(option);
@@ -605,7 +846,7 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__parse__option__short_name__boolean() {
+    void COMMAND_FRAMEWORK__parse__option__short_name__boolean__base_command() {
         boolean expected = true;
         Option option = getOption();
         addOptionShortName(option);
@@ -618,7 +859,7 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__parse__option__long_name__string() {
+    void COMMAND_FRAMEWORK__parse__option__long_name__string__base_command() {
         String expected = "option value";
         Option option = getOption();
         addOptionLabel(option);
@@ -631,7 +872,7 @@ public class CommandFrameworkTest {
     }
 
     @Test
-    void COMMAND_FRAMEWORK__parse__option__short_name__string() {
+    void COMMAND_FRAMEWORK__parse__option__short_name__string__base_command() {
         String expected = "option value";
         Option option = getOption();
         addOptionShortName(option);
@@ -641,6 +882,89 @@ public class CommandFrameworkTest {
         commandFramework.execute(new String[]{option.getShortName(), expected});
 
         String actual = frameworkBaseCommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__positional_parameter__subcommand() {
+        String expected = "first positional parameter value";
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        subcommand.addPositionalParameter(getPositionalParameter());
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), expected});
+
+        String actual = subcommand.getPositionalParameters().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__boolean__subcommand() {
+        boolean expected = true;
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        Option option = getOption();
+        subcommand.addOption(option);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), option.getLongName()});
+
+        boolean actual = (boolean) subcommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__boolean__subcommand() {
+        boolean expected = true;
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        Option option = getOption();
+        addOptionShortName(option);
+        subcommand.addOption(option);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), option.getShortName()});
+
+        boolean actual = (boolean) subcommand.getOptions().get(0).getValue();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__long_name__string__subcommand() {
+        String expected = "option value";
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        Option option = getOption();
+        addOptionLabel(option);
+        subcommand.addOption(option);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), option.getLongName(), expected});
+
+        String actual = subcommand.getOptions().get(0).getValue().toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void COMMAND_FRAMEWORK__parse__option__short_name__string__subcommand() {
+        String expected = "option value";
+
+        FrameworkBaseCommand subcommand = getSubcommand();
+        Option option = getOption();
+        addOptionShortName(option);
+        addOptionLabel(option);
+        subcommand.addOption(option);
+        frameworkBaseCommand.addFrameworkSubcommand(subcommand);
+
+        CommandFramework commandFramework = new CommandFramework(frameworkBaseCommand);
+        commandFramework.execute(new String[]{subcommand.getName(), option.getShortName(), expected});
+
+        String actual = subcommand.getOptions().get(0).getValue().toString();
         assertEquals(expected, actual);
     }
 }

--- a/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
+++ b/sdk/command/src/test/java/com/blckroot/sdk/command/framework/command/decorator/framework/SetAttributesFromPropertiesFileTest.java
@@ -48,6 +48,14 @@ public class SetAttributesFromPropertiesFileTest {
     }
 
     @Test
+    void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__properties() throws Exception {
+        FrameworkBaseCommand command = new SetAttributesFromPropertiesFile(
+                new FrameworkCommand("test"), VALID_PROPERTIES_DIRECTORY);
+        command.call();
+        assertNotNull(command.getProperties());
+    }
+
+    @Test
     void SET_ATTRIBUTES_FROM_PROPERTIES_FILE__valid__version() throws Exception {
         FileSystemService fileSystemService = new FileSystemService();
         Properties properties = fileSystemService.getPropertiesFromFile(VALID_PROPERTIES_FILE_PATH);


### PR DESCRIPTION
- enhanced CommandFramework to manually parse positional parameters, setting positional parameter values dynamically.
- enhanced CommandFramework to manually parse options, setting option values dynamically.
- enhanced CommandFramework to manually parse positional parameters for subcommands, setting positional parameter values dynamically.
- enhanced CommandFramework to manually parse options for subcommand, setting option values dynamically.
- enhanced CommandFramework to manually parse positonal parameters for nested subcommand, setting positional parameter values dynamically.
- enhanced CommandFramework to manually parse options for nested subcommands, setting option values dynamically.
- enhanced CommandFramework to execute 'call' method for FrameworkCommand after parsing has been completed.